### PR TITLE
Added support for Oauth2 Authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Simplifies integration with the Fortnox API.
 - PHP 8.0 or higher
 - Valid client id (from Fortnox)
 - Valid client secret (from Fortnox)
-- Valid refresh token (from Fortnox)
+- (Optional) Valid refresh token (from Fortnox)
 
 ## Installation
 
@@ -21,14 +21,38 @@ composer require kfoobar/laravel-fortnox
 `
 
 ## Settings for .env
-
+The `FORTNOX_REFRESH_TOKEN` is only required if the oauth autentication is not used.
+The token driver can either be `cache`, `file` or `session` and is used for storing the access_token and refresh token.
 ```
 FORTNOX_CLIENT_ID=
 FORTNOX_CLIENT_SECRET=
-FORTNOX_REFRESH_TOKEN=
+FORTNOX_REFRESH_TOKEN= 
+FORTNOX_TOKEN_DRIVER= 
+FORTNOX_OAUTH_SCOPE=
+FORTNOX_REDIRECT_URL=
+```
+## Authorization with Oauth2
+
+To authenticate against to the Fortnox integration using Oauth2 you can use the
+built in Oauth2 routes.
+
+In your route file:
+```php
+use KFoobar\Fortnox\Facades\FortnoxAuthenticator;
+
+FortnoxAuthenticator::routes();
 ```
 
-## Fortnox authorization
+To start the authentication you navigate to the route `fortnox.oauth.authorize`
+
+You need to provide the scope as a comma separated list in the env variable `FORTNOX_OAUTH_SCOPE`
+See valid scope at: https://www.fortnox.se/developer/guides-and-good-to-know/scopes
+
+Once the authorization flow is completed the user will be redirected to the url in the env variable `FORTNOX_REDIRECT_URL`
+
+The login can be verified with `FortnoxAuthenticator::isAuthenticated()`
+
+## Authorization with provided refresh token
 
 In order to use the Fortnox API, you need a valid refresh token. 
 To get a refresh token, you need to grant access to the integration via Fortnox's OAuth2 
@@ -56,8 +80,23 @@ php artisan fortnox:refresh
 Keep this in mind when you purge the cache or changes cache driver.*
 
 ## Instructions
+The objects are following the naming convention of the Fortnox Developer Guide and has the same operations.
 
-Coming soon...
+### Retrieving Objects
+
+#### Retrieve all customers
+```php
+    Fortnox::customers()->all(); 
+```
+
+#### Retrieve a single customer
+```php
+    Fortnox::customers()->get('1234'); 
+```
+
+More instructions will come soon..
+
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,30 @@
 # Fortnox API Client for Laravel
 
-Simplifies integration with the Fortnox API.
+A Laravel package that simplifies integration with the Fortnox API.
 
-*Please notice! This package does not yet support all available resources in the Fortnox API*
+> **Note**: This package does not yet support all available resources in the Fortnox API.
 
 ## Requirements
 
-- Laravel 6 or higher
+- Laravel 6.x or higher
 - PHP 8.0 or higher
-- Valid client id (from Fortnox)
-- Valid client secret (from Fortnox)
-- (Optional) Valid refresh token (from Fortnox)
+- A valid Fortnox client ID
+- A valid Fortnox client secret
+- (Optional) A valid refresh token if not using OAuth2 authentication
 
 ## Installation
 
-You can install the package via Composer:
+Install the package via Composer:
 
-`
-composer require kfoobar/laravel-fortnox 
-`
-
-## Settings for .env
-The `FORTNOX_REFRESH_TOKEN` is only required if the oauth autentication is not used.
-The token driver can either be `cache`, `file` or `session` and is used for storing the access_token and refresh token.
+```bash
+composer require kfoobar/laravel-fortnox
 ```
+
+## Environment Configuration
+
+Add the following settings to your `.env` file. The `FORTNOX_REFRESH_TOKEN` is only required if OAuth authentication is not used. The `FORTNOX_TOKEN_DRIVER` determines where the access and refresh tokens are stored, with options being `cache`, `file`, or `session`.
+
+```env
 FORTNOX_CLIENT_ID=
 FORTNOX_CLIENT_SECRET=
 FORTNOX_REFRESH_TOKEN= 
@@ -31,77 +32,67 @@ FORTNOX_TOKEN_DRIVER=
 FORTNOX_OAUTH_SCOPE=
 FORTNOX_REDIRECT_URL=
 ```
-## Authorization with Oauth2
 
-To authenticate against to the Fortnox integration using Oauth2 you can use the
-built in Oauth2 routes.
+## Authentication
+
+### OAuth2 Authentication
+
+To authenticate with Fortnox using OAuth2, use the built-in OAuth2 routes:
 
 In your route file:
+
 ```php
 use KFoobar\Fortnox\Facades\FortnoxAuthenticator;
 
 FortnoxAuthenticator::routes();
 ```
 
-To start the authentication you navigate to the route `fortnox.oauth.authorize`
+Navigate to the `fortnox.oauth.authorize` route to start the authorization process.  
+Set the desired OAuth scopes as a comma-separated list in `FORTNOX_OAUTH_SCOPE`. You can find valid scope options [here](https://www.fortnox.se/developer/guides-and-good-to-know/scopes).
 
-You need to provide the scope as a comma separated list in the env variable `FORTNOX_OAUTH_SCOPE`
-See valid scope at: https://www.fortnox.se/developer/guides-and-good-to-know/scopes
+Upon successful authorization, users are redirected to the URL specified in `FORTNOX_REDIRECT_URL`. You can check the authentication status with `FortnoxAuthenticator::isAuthenticated()`.
 
-Once the authorization flow is completed the user will be redirected to the url in the env variable `FORTNOX_REDIRECT_URL`
+### Using a Provided Refresh Token
 
-The login can be verified with `FortnoxAuthenticator::isAuthenticated()`
+If you already have a refresh token, you can authenticate directly using that token.
 
-## Authorization with provided refresh token
+1. Obtain a refresh token by granting access to the integration through Fortnox's OAuth2 authorization code flow.
+2. Use the authorization code to retrieve both an access token (valid for 1 hour) and a refresh token (valid for 30 days).
 
-In order to use the Fortnox API, you need a valid refresh token. 
-To get a refresh token, you need to grant access to the integration via Fortnox's OAuth2 
-authorization code flow. In that process, you are assigned an *authorization code*
-that you can use to exchange for a pair of token:
+This package automatically refreshes the access token if a valid refresh token is available. **Note**: Each time the access token is renewed, a new refresh token is issued, valid for an additional 30 days.
 
-The **access token** - which is used to authenticate all API request - is only valid 
-for 1 hour and needs to be refreshed using a refresh token. This package handles 
-that process as long you have a valid refresh token.
+To manually renew tokens, run:
 
-The **refresh token** - which is used to renew the access token - is valid for 30 days. 
-If it expires, you need to redo the OAuth2 authorization flow.
-
-Every time you renew you access token, you will be assigned a new refresh token that 
-is valid for another 30 days. It is therefore important that you regularly renew 
-the tokens so that the refresh token does not expire.
-
-You can renew your tokens with the following command:
-
-```
+```bash
 php artisan fortnox:refresh
 ```
 
-*Both the access token and the refresh token are stored in your application's cache.
-Keep this in mind when you purge the cache or changes cache driver.*
+> **Important**: Both tokens are stored based on your chosen `FORTNOX_TOKEN_DRIVER` (cache, file, or session). Be mindful of this when clearing cache or switching storage drivers.
 
-## Instructions
-The objects are following the naming convention of the Fortnox Developer Guide and has the same operations.
+## Usage
+
+This package follows Fortnox's naming conventions and operations as described in the [Fortnox Developer Guide](https://www.fortnox.se/developer/). Below are some examples:
 
 ### Retrieving Objects
 
-#### Retrieve all customers
+#### Retrieve All Customers
+
 ```php
-    Fortnox::customers()->all(); 
+Fortnox::customers()->all();
 ```
 
-#### Retrieve a single customer
+#### Retrieve a Single Customer
+
 ```php
-    Fortnox::customers()->get('1234'); 
+Fortnox::customers()->get('1234');
 ```
 
-More instructions will come soon..
-
-
+Additional usage instructions and supported operations will be added soon.
 
 ## Contributing
 
-Contributions are welcome!
+Contributions are welcome! Please feel free to submit pull requests or issues.
 
 ## License
 
-The MIT License (MIT). Please see [License File](LICENSE) for more information.
+This package is open-sourced software licensed under the [MIT License](LICENSE).

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
                 "KFoobar\\Fortnox\\FortnoxServiceProvider"
             ],
             "aliases": {
-                "Fortnox": "KFoobar\\Fortnox\\Facades\\Fortnox"
+                "Fortnox": "KFoobar\\Fortnox\\Facades\\Fortnox",
+                "FortnoxAuthenticator": "KFoobar\\Fortnox\\Facades\\FortnoxAuthenticator"
             }
         }
     }

--- a/config/fortnox.php
+++ b/config/fortnox.php
@@ -8,5 +8,6 @@ return [
     'refresh_token' => env('FORTNOX_REFRESH_TOKEN', ''),
     'timeout'       => env('FORTNOX_TIMEOUT', 5),
     'scope'         => env('FORTNOX_SCOPE', ''), #Comma separated list of scopes
+    'oauth_redirect_url' => env('FORTNOX_REDIRECT_URL', '/'),
 
 ];

--- a/config/fortnox.php
+++ b/config/fortnox.php
@@ -2,12 +2,14 @@
 
 return [
 
-    'host'          => env('FORTNOX_HOST', 'https://api.fortnox.se/3/'),
-    'client_id'     => env('FORTNOX_CLIENT_ID', ''),
+    'host'  => env('FORTNOX_HOST', 'https://api.fortnox.se/3/'),
+    'client_id' => env('FORTNOX_CLIENT_ID', ''),
     'client_secret' => env('FORTNOX_CLIENT_SECRET', ''),
     'refresh_token' => env('FORTNOX_REFRESH_TOKEN', ''),
-    'timeout'       => env('FORTNOX_TIMEOUT', 5),
-    'scope'         => env('FORTNOX_SCOPE', ''), #Comma separated list of scopes
+    'timeout' => env('FORTNOX_TIMEOUT', 5),
+    'token_store' => env('FORTNOX_TOKEN_STORE', 'cache'), #cache or file
+    'oauth_scope' => env('FORTNOX_OAUTH_SCOPE', ''), #Comma separated list of scopes
     'oauth_redirect_url' => env('FORTNOX_REDIRECT_URL', '/'),
+
 
 ];

--- a/config/fortnox.php
+++ b/config/fortnox.php
@@ -7,7 +7,7 @@ return [
     'client_secret' => env('FORTNOX_CLIENT_SECRET', ''),
     'refresh_token' => env('FORTNOX_REFRESH_TOKEN', ''),
     'timeout' => env('FORTNOX_TIMEOUT', 5),
-    'token_store' => env('FORTNOX_TOKEN_STORE', 'cache'), #cache or file
+    'token_driver' => env('FORTNOX_TOKEN_DRIVER', 'cache'), #cache or file
     'oauth_scope' => env('FORTNOX_OAUTH_SCOPE', ''), #Comma separated list of scopes
     'oauth_redirect_url' => env('FORTNOX_REDIRECT_URL', '/'),
 

--- a/config/fortnox.php
+++ b/config/fortnox.php
@@ -7,5 +7,6 @@ return [
     'client_secret' => env('FORTNOX_CLIENT_SECRET', ''),
     'refresh_token' => env('FORTNOX_REFRESH_TOKEN', ''),
     'timeout'       => env('FORTNOX_TIMEOUT', 5),
+    'scope'         => env('FORTNOX_SCOPE', ''), #Comma separated list of scopes
 
 ];

--- a/config/fortnox.php
+++ b/config/fortnox.php
@@ -7,9 +7,7 @@ return [
     'client_secret' => env('FORTNOX_CLIENT_SECRET', ''),
     'refresh_token' => env('FORTNOX_REFRESH_TOKEN', ''),
     'timeout' => env('FORTNOX_TIMEOUT', 5),
-    'token_driver' => env('FORTNOX_TOKEN_DRIVER', 'cache'), #cache or file
+    'token_driver' => env('FORTNOX_TOKEN_DRIVER', 'cache'), #cache, session, file
     'oauth_scope' => env('FORTNOX_OAUTH_SCOPE', ''), #Comma separated list of scopes
     'oauth_redirect_url' => env('FORTNOX_REDIRECT_URL', '/'),
-
-
 ];

--- a/src/Commands/DisplayTokensCommand.php
+++ b/src/Commands/DisplayTokensCommand.php
@@ -3,7 +3,7 @@
 namespace KFoobar\Fortnox\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Cache;
+use KFoobar\Fortnox\Services\Token;
 
 class DisplayTokensCommand extends Command
 {
@@ -29,11 +29,11 @@ class DisplayTokensCommand extends Command
     public function handle()
     {
         $this->components->info(
-            'Access token: ' . Cache::get('fortnox-access-token', 'Missing')
+            'Access token: ' . Token::get('fortnox-access-token') ?? 'Missing'
         );
 
         $this->components->info(
-            'Refresh token: ' . Cache::get('fortnox-refresh-token', 'Missing')
+            'Refresh token: ' . Token::get('fortnox-refresh-token') ?? 'Missing'
         );
 
         return Command::SUCCESS;

--- a/src/Commands/PurgeTokensCommand.php
+++ b/src/Commands/PurgeTokensCommand.php
@@ -3,7 +3,7 @@
 namespace KFoobar\Fortnox\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Cache;
+use KFoobar\Fortnox\Services\Token;
 
 class PurgeTokensCommand extends Command
 {
@@ -35,8 +35,8 @@ class PurgeTokensCommand extends Command
         }
 
         try {
-            Cache::forget('fortnox-access-token');
-            Cache::forget('fortnox-refresh-token');
+            Token::forget('fortnox-access-token');
+            Token::forget('fortnox-refresh-token');
         } catch (\Exception) {
             $this->components->error('Failed to cached tokens!');
 

--- a/src/Controllers/FortnoxOauthController.php
+++ b/src/Controllers/FortnoxOauthController.php
@@ -1,0 +1,26 @@
+<?php
+namespace KFoobar\Fortnox\Controllers;
+use KFoobar\Fortnox\Facades\FortnoxAuthenticator;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Cache;
+class FortnoxOauthController extends Controller {
+
+    public function authorize() {
+
+        $scope = explode(',', config('fortnox.scope'));
+        return redirect()->away(FortnoxAuthenticator::AuthUrl($scope));
+    }
+
+    public function callback() {
+        $code = request()->get('code');
+        $state = request()->get('state');
+        
+        //Validate state
+        if ($state !== Cache::get('fortnox-oauth-state')) {
+            return response()->json(['error' => 'Invalid state'], 400);
+        }
+
+        dd($code);
+    }
+
+}

--- a/src/Controllers/FortnoxOauthController.php
+++ b/src/Controllers/FortnoxOauthController.php
@@ -18,11 +18,14 @@ class FortnoxOauthController extends Controller {
         $state = request()->get('state');
         
         //Validate state
-        if ($state !== Cache::get('fortnox-oauth-state')) {
-            return response()->json(['error' => 'Invalid state'], 400);
+        if (!$state || $state !== Cache::get('fortnox-oauth-state')) {
+            abort(403, 'Invalid state');
         }
 
-        dd($code);
+        FortnoxAuthenticator::authorize($code);
+
+        return redirect()->to(config('fortnox.oauth_redirect_url'));
+
     }
 
 }

--- a/src/Controllers/FortnoxOauthController.php
+++ b/src/Controllers/FortnoxOauthController.php
@@ -8,7 +8,9 @@ class FortnoxOauthController extends Controller {
     public function authorize() {
 
         $scope = explode(',', config('fortnox.scope'));
-        return redirect()->away(FortnoxAuthenticator::AuthUrl($scope));
+        $state = bin2hex(random_bytes(16));
+        Cache::put('fortnox-oauth-state', $state, 300);
+        return redirect()->away(FortnoxAuthenticator::AuthUrl($scope, $state));
     }
 
     public function callback() {

--- a/src/Controllers/FortnoxOauthController.php
+++ b/src/Controllers/FortnoxOauthController.php
@@ -5,6 +5,11 @@ use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Cache;
 class FortnoxOauthController extends Controller {
 
+
+    /**
+     * Redirect to Fortnox for authorization
+     * @return \Illuminate\Http\RedirectResponse
+     */
     public function authorize() {
 
         $scope = explode(',', config('fortnox.oauth_scope'));
@@ -13,11 +18,15 @@ class FortnoxOauthController extends Controller {
         return redirect()->away(FortnoxAuthenticator::AuthUrl($scope, $state));
     }
 
+    /**
+     * Callback from Fortnox after authorization
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    
     public function callback() {
         $code = request()->get('code');
         $state = request()->get('state');
         
-        //Validate state
         if (!$state || $state !== Cache::get('fortnox-oauth-state')) {
             abort(403, 'Invalid state');
         }

--- a/src/Controllers/FortnoxOauthController.php
+++ b/src/Controllers/FortnoxOauthController.php
@@ -7,7 +7,7 @@ class FortnoxOauthController extends Controller {
 
     public function authorize() {
 
-        $scope = explode(',', config('fortnox.scope'));
+        $scope = explode(',', config('fortnox.oauth_scope'));
         $state = bin2hex(random_bytes(16));
         Cache::put('fortnox-oauth-state', $state, 300);
         return redirect()->away(FortnoxAuthenticator::AuthUrl($scope, $state));
@@ -20,6 +20,10 @@ class FortnoxOauthController extends Controller {
         //Validate state
         if (!$state || $state !== Cache::get('fortnox-oauth-state')) {
             abort(403, 'Invalid state');
+        }
+
+        if(!$code) {
+            abort(403, 'Missing code');
         }
 
         FortnoxAuthenticator::authorize($code);

--- a/src/Controllers/FortnoxOauthController.php
+++ b/src/Controllers/FortnoxOauthController.php
@@ -3,15 +3,16 @@ namespace KFoobar\Fortnox\Controllers;
 use KFoobar\Fortnox\Facades\FortnoxAuthenticator;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Cache;
-class FortnoxOauthController extends Controller {
+class FortnoxOauthController extends Controller 
+{
 
 
     /**
      * Redirect to Fortnox for authorization
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function authorize() {
-
+    public function authorize() 
+    {
         $scope = explode(',', config('fortnox.oauth_scope'));
         $state = bin2hex(random_bytes(16));
         Cache::put('fortnox-oauth-state', $state, 300);
@@ -22,8 +23,8 @@ class FortnoxOauthController extends Controller {
      * Callback from Fortnox after authorization
      * @return \Illuminate\Http\RedirectResponse
      */
-    
-    public function callback() {
+    public function callback() 
+    {
         $code = request()->get('code');
         $state = request()->get('state');
         
@@ -38,7 +39,6 @@ class FortnoxOauthController extends Controller {
         FortnoxAuthenticator::authorize($code);
 
         return redirect()->to(config('fortnox.oauth_redirect_url'));
-
     }
 
 }

--- a/src/Facades/FortnoxAuthenticator.php
+++ b/src/Facades/FortnoxAuthenticator.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace KFoobar\Fortnox\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class FortnoxAuthenticator extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return \KFoobar\Fortnox\Services\Authenticator::class;
+    }
+}

--- a/src/Services/Authenticator.php
+++ b/src/Services/Authenticator.php
@@ -5,9 +5,17 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Http;
 use KFoobar\Fortnox\Exceptions\FortnoxException;
+use KFoobar\Fortnox\Services\Token;
 class Authenticator {
 
-    public function authUrl($scope = [], $state = null): string
+
+    /**
+     * Returns the authorization URL.
+     * @param array $scope
+     * @param string $state
+     * @return string
+     */
+    public function authUrl(array $scope = [], string $state = null): string
     {
         if(is_null($state)) {
             $state = bin2hex(random_bytes(16));
@@ -26,7 +34,14 @@ class Authenticator {
         return sprintf('https://apps.fortnox.se/oauth-v1/auth?%s', $query);
     }
 
-    public function authorize($code) {
+
+    /**
+     * Authorize the integration using provided authorization code.
+     * @param string $code
+     * @return void
+     */
+    public function authorize(string $code) : void 
+    {
         $response = Http::withBasicAuth(config('fortnox.client_id'), config('fortnox.client_secret'))
             ->asForm()
             ->post('https://apps.fortnox.se/oauth-v1/token', [
@@ -35,7 +50,6 @@ class Authenticator {
                 'redirect_uri'  => route('fortnox.oauth.callback'),
             ]);
         
-        dd($response, $response->json());
         if ($response->failed()) {
             throw new FortnoxException('Failed to authorize.');
         }
@@ -44,13 +58,16 @@ class Authenticator {
             throw new FortnoxException('Failed to retrieve access token from response.');
         }
 
-      
-
-        Cache::put('fortnox-access-token', $response->json('access_token'), $response->json('expires_in'));
-        Cache::put('fortnox-refresh-token', $response->json('refresh_token'), 2160000);
+        Token::put('fortnox-access-token', $response->json('access_token'), $response->json('expires_in'));
+        Token::put('fortnox-refresh-token', $response->json('refresh_token'), 2160000);
     }
 
-    public function routes() {
+    /**
+     * Register laravel routes.
+     * @return void
+     */
+    public function routes() 
+    {
         Route::get('fortnox/oauth/authorize', [FortnoxOauthController::class, 'authorize'])->name('fortnox.oauth.authorize');
         Route::get('fortnox/oauth/callback', [FortnoxOauthController::class, 'callback'])->name('fortnox.oauth.callback');
     }

--- a/src/Services/Authenticator.php
+++ b/src/Services/Authenticator.php
@@ -1,0 +1,36 @@
+<?php
+namespace KFoobar\Fortnox\Services;
+use KFoobar\Fortnox\Services\Client;
+use KFoobar\Fortnox\Controllers\FortnoxOauthController;
+use Illuminate\Support\Facades\Cache;
+class Authenticator {
+    protected $client;
+    public function __construct()
+    {
+        $this->client = new Client;
+    }
+
+    public function authUrl($scope = []): string
+    {
+        $state = uuid();
+        Cache::put('fortnox-oauth-state', $state, 300);
+
+        $query = http_build_query([
+            'client_id'     => $this->client->getClientId(),
+            'redirect_uri'  => route('fortnox.oauth.callback'),
+            'response_type' => 'code',
+            'scope'         => implode(',', $scope),
+            'state'         => $state,
+        ]);
+
+        return sprintf('https://apps.fortnox.se/oauth-v1/auth?%s', $query);
+    }
+
+    public function routes() {
+        Route::get('fortnox/oauth/authorize', [FortnoxOauthController::class, 'authorize'])->name('fortnox.oauth.authorize');
+        Route::get('fortnox/oauth/callback', [FortnoxOauthController::class, 'callback'])->name('fortnox.oauth.callback');
+    }
+
+
+
+}

--- a/src/Services/Authenticator.php
+++ b/src/Services/Authenticator.php
@@ -2,6 +2,7 @@
 namespace KFoobar\Fortnox\Services;
 use KFoobar\Fortnox\Controllers\FortnoxOauthController;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Route;
 class Authenticator {
 
     public function authUrl($scope = []): string

--- a/src/Services/Authenticator.php
+++ b/src/Services/Authenticator.php
@@ -32,7 +32,7 @@ class Authenticator {
             ->post('https://apps.fortnox.se/oauth-v1/token', [
                 'grant_type'    => 'authorization_code',
                 'code'          => $code,
-                'redirect_uri'  => config('app.url'),
+                'redirect_uri'  => route('fortnox.oauth.callback'),
             ]);
         
         dd($response, $response->json());

--- a/src/Services/Authenticator.php
+++ b/src/Services/Authenticator.php
@@ -3,6 +3,8 @@ namespace KFoobar\Fortnox\Services;
 use KFoobar\Fortnox\Controllers\FortnoxOauthController;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Http;
+use KFoobar\Fortnox\Exceptions\FortnoxException;
 class Authenticator {
 
     public function authUrl($scope = [], $state = null): string
@@ -17,9 +19,34 @@ class Authenticator {
             'response_type' => 'code',
             'scope'         => implode(',', $scope),
             'state'         => $state,
+            'access_type'   => 'offline',
+            'account_type'  => 'service',
         ]);
 
         return sprintf('https://apps.fortnox.se/oauth-v1/auth?%s', $query);
+    }
+
+    public function authorize($authorizationCode) {
+        $response = Http::withBasicAuth(config('fortnox.client_id'), config('fortnox.client_secret'))
+            ->asForm()
+            ->post('https://apps.fortnox.se/oauth-v1/token', [
+                'grant_type'    => 'authorization_code',
+                'code'          => $authorizationCode,
+            ]);
+        
+        dd($response);
+        if ($response->failed()) {
+            throw new FortnoxException('Failed to authorize.');
+        }
+
+        if (empty($response->json('access_token'))) {
+            throw new FortnoxException('Failed to retrieve access token from response.');
+        }
+
+      
+
+        Cache::put('fortnox-access-token', $response->json('access_token'), $response->json('expires_in'));
+        Cache::put('fortnox-refresh-token', $response->json('refresh_token'), 2160000);
     }
 
     public function routes() {

--- a/src/Services/Authenticator.php
+++ b/src/Services/Authenticator.php
@@ -5,11 +5,12 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Route;
 class Authenticator {
 
-    public function authUrl($scope = []): string
+    public function authUrl($scope = [], $state = null): string
     {
-        $state = uuid();
-        Cache::put('fortnox-oauth-state', $state, 300);
-
+        if(is_null($state)) {
+            $state = bin2hex(random_bytes(16));
+        }
+        
         $query = http_build_query([
             'client_id'     => config('fortnox.client_id'),
             'redirect_uri'  => route('fortnox.oauth.callback'),

--- a/src/Services/Authenticator.php
+++ b/src/Services/Authenticator.php
@@ -1,14 +1,8 @@
 <?php
 namespace KFoobar\Fortnox\Services;
-use KFoobar\Fortnox\Services\Client;
 use KFoobar\Fortnox\Controllers\FortnoxOauthController;
 use Illuminate\Support\Facades\Cache;
 class Authenticator {
-    protected $client;
-    public function __construct()
-    {
-        $this->client = new Client;
-    }
 
     public function authUrl($scope = []): string
     {
@@ -16,7 +10,7 @@ class Authenticator {
         Cache::put('fortnox-oauth-state', $state, 300);
 
         $query = http_build_query([
-            'client_id'     => $this->client->getClientId(),
+            'client_id'     => config('fortnox.client_id'),
             'redirect_uri'  => route('fortnox.oauth.callback'),
             'response_type' => 'code',
             'scope'         => implode(',', $scope),

--- a/src/Services/Authenticator.php
+++ b/src/Services/Authenticator.php
@@ -73,5 +73,15 @@ class Authenticator {
     }
 
 
+    /**
+     * Return true if the user is authenticated.
+     * @return bool
+     */
+    public function isAuthenticated() : bool
+    {
+        return !empty(Token::get('fortnox-access-token')) || !empty(Token::get('fortnox-refresh-token'));
+    }
+
+
 
 }

--- a/src/Services/Authenticator.php
+++ b/src/Services/Authenticator.php
@@ -32,6 +32,7 @@ class Authenticator {
             ->post('https://apps.fortnox.se/oauth-v1/token', [
                 'grant_type'    => 'authorization_code',
                 'code'          => $code,
+                'redirect_uri'  => config('app.url'),
             ]);
         
         dd($response, $response->json());

--- a/src/Services/Authenticator.php
+++ b/src/Services/Authenticator.php
@@ -25,7 +25,7 @@ class Authenticator {
             'client_id'     => config('fortnox.client_id'),
             'redirect_uri'  => route('fortnox.oauth.callback'),
             'response_type' => 'code',
-            'scope'         => implode(',', $scope),
+            'scope'         => implode(' ', $scope),
             'state'         => $state,
             'access_type'   => 'offline',
             'account_type'  => 'service',

--- a/src/Services/Authenticator.php
+++ b/src/Services/Authenticator.php
@@ -26,15 +26,15 @@ class Authenticator {
         return sprintf('https://apps.fortnox.se/oauth-v1/auth?%s', $query);
     }
 
-    public function authorize($authorizationCode) {
+    public function authorize($code) {
         $response = Http::withBasicAuth(config('fortnox.client_id'), config('fortnox.client_secret'))
             ->asForm()
             ->post('https://apps.fortnox.se/oauth-v1/token', [
                 'grant_type'    => 'authorization_code',
-                'code'          => $authorizationCode,
+                'code'          => $code,
             ]);
         
-        dd($response);
+        dd($response, $response->json());
         if ($response->failed()) {
             throw new FortnoxException('Failed to authorize.');
         }

--- a/src/Services/Token.php
+++ b/src/Services/Token.php
@@ -1,0 +1,119 @@
+<?php
+namespace KFoobar\Fortnox\Services;
+use Illuminate\Support\Facades\Cache;
+use KFoobar\Fortnox\Exceptions\FortnoxException;
+class Token 
+{
+
+    /**
+     * Get a token
+     * @param string $name
+     * @throws FortnoxException
+     * @return string
+     */
+    public static function get(string $name) : string
+    {
+        switch(config('fortnox.token_storage')) {
+            case 'cache':
+                return Cache::get($name);
+            case 'session':
+                return session($name);
+            case 'file':
+                return self::readFile($name);
+            default:
+                throw new FortnoxException('Invalid token storage type: '.config('fortnox.token_storage'));
+        }
+    } 
+    
+    /**
+     * Store a token
+     * @param string $name
+     * @param string $value
+     * @param int $expiration
+     * @throws FortnoxException
+     * @return string
+     */
+    public static function put(string $name, string $value, int $expiration = 60) : string
+    {
+        switch(config('fortnox.token_storage')) {
+            case 'cache':
+                Cache::put($name, $value, $expiration);
+                break;
+            case 'session':
+                session([$name => $value]);
+                break;
+            case 'file':
+                self::writeFile($name, $value, $expiration);
+                break;
+            default:
+                throw new FortnoxException('Invalid token storage type: '.config('fortnox.token_storage'));
+        }
+
+        return $value;
+    }
+
+    /**
+     * Check if a token exists
+     * @param string $name
+     * @throws FortnoxException
+     * @return bool
+     */
+    public static function has(string $name) : bool
+     {
+        switch(config('fortnox.token_storage')) {
+            case 'cache':
+                return Cache::has($name);
+            case 'session':
+                return session()->has($name);
+            case 'file':
+                return self::readFile($name) !== null;
+            default:
+                throw new FortnoxException('Invalid token storage type: '.config('fortnox.token_storage'));
+        }
+    }
+
+
+    /**
+     * Read a token from file
+     * @param string $name
+     * @return string|null
+     */
+    private static function readFile(string $name) : ?string 
+    {
+        if(!file_exists(storage_path('app/fortnox/'.$name))) {
+            return null;
+        }
+        $data =  json_decode(file_get_contents(storage_path('app/fortnox/'.$name)));
+
+        if($data->expiration < time()) {
+            unlink(storage_path('app/fortnox/'.$name));
+            return null;
+        }
+
+        return $data->value;
+    }
+
+
+    /**
+     * Write a token to file
+     * @param string $name
+     * @param string $value
+     * @param int $expiration
+     * @return void
+     */
+    private static function writeFile(string $name, string $value, int $expiration) : void {
+
+        if (!is_dir(storage_path('app/fortnox'))) {
+            mkdir(storage_path('app/fortnox'));
+        }
+
+        $data = json_encode([
+            'value' => $value,
+            'expiration' => time() + $expiration
+        ]);
+
+        file_put_contents(storage_path('app/fortnox/'.$name), $data);
+    }
+
+    
+}

--- a/src/Services/Token.php
+++ b/src/Services/Token.php
@@ -2,7 +2,7 @@
 namespace KFoobar\Fortnox\Services;
 use Illuminate\Support\Facades\Cache;
 use KFoobar\Fortnox\Exceptions\FortnoxException;
-class Token 
+class Token
 {
 
     /**
@@ -11,7 +11,7 @@ class Token
      * @throws FortnoxException
      * @return string
      */
-    public static function get(string $name) : string
+    public static function get(string $name) : ?string
     {
         switch(config('fortnox.token_driver')) {
             case 'cache':
@@ -23,8 +23,8 @@ class Token
             default:
                 throw new FortnoxException('Invalid token storage driver: '.config('fortnox.token_driver'));
         }
-    } 
-    
+    }
+
     /**
      * Store a token
      * @param string $name
@@ -102,7 +102,7 @@ class Token
      * @param string $name
      * @return string|null
      */
-    private static function readFile(string $name) : ?string 
+    private static function readFile(string $name) : ?string
     {
         if(!file_exists(storage_path('app/fortnox/'.$name))) {
             return null;
@@ -140,5 +140,5 @@ class Token
         file_put_contents(storage_path('app/fortnox/'.$name), $data);
     }
 
-    
+
 }

--- a/src/Services/Token.php
+++ b/src/Services/Token.php
@@ -13,7 +13,7 @@ class Token
      */
     public static function get(string $name) : string
     {
-        switch(config('fortnox.token_storage')) {
+        switch(config('fortnox.token_driver')) {
             case 'cache':
                 return Cache::get($name);
             case 'session':
@@ -21,7 +21,7 @@ class Token
             case 'file':
                 return self::readFile($name);
             default:
-                throw new FortnoxException('Invalid token storage type: '.config('fortnox.token_storage'));
+                throw new FortnoxException('Invalid token storage driver: '.config('fortnox.token_driver'));
         }
     } 
     
@@ -35,7 +35,7 @@ class Token
      */
     public static function put(string $name, string $value, int $expiration = 60) : string
     {
-        switch(config('fortnox.token_storage')) {
+        switch(config('fortnox.token_driver')) {
             case 'cache':
                 Cache::put($name, $value, $expiration);
                 break;
@@ -46,7 +46,7 @@ class Token
                 self::writeFile($name, $value, $expiration);
                 break;
             default:
-                throw new FortnoxException('Invalid token storage type: '.config('fortnox.token_storage'));
+                throw new FortnoxException('Invalid token driver: '.config('fortnox.token_driver'));
         }
 
         return $value;
@@ -60,7 +60,7 @@ class Token
      */
     public static function has(string $name) : bool
      {
-        switch(config('fortnox.token_storage')) {
+        switch(config('fortnox.token_driver')) {
             case 'cache':
                 return Cache::has($name);
             case 'session':
@@ -68,7 +68,7 @@ class Token
             case 'file':
                 return self::readFile($name) !== null;
             default:
-                throw new FortnoxException('Invalid token storage type: '.config('fortnox.token_storage'));
+                throw new FortnoxException('Invalid token driver: '.config('fortnox.token_driver'));
         }
     }
 

--- a/src/Services/Token.php
+++ b/src/Services/Token.php
@@ -125,7 +125,8 @@ class Token
      * @param int $expiration
      * @return void
      */
-    private static function writeFile(string $name, string $value, int $expiration) : void {
+    private static function writeFile(string $name, string $value, int $expiration) : void
+    {
 
         if (!is_dir(storage_path('app/fortnox'))) {
             mkdir(storage_path('app/fortnox'));

--- a/src/Services/Token.php
+++ b/src/Services/Token.php
@@ -53,6 +53,30 @@ class Token
     }
 
     /**
+     * Forget a token
+     * @param string $name
+     * @throws FortnoxException
+     * @return void
+     */
+    public static function forget($name) {
+        switch(config('fortnox.token_driver')) {
+            case 'cache':
+                Cache::forget($name);
+                break;
+            case 'session':
+                session()->forget($name);
+                break;
+            case 'file':
+                if(file_exists(storage_path('app/fortnox/'.$name))) {
+                    unlink(storage_path('app/fortnox/'.$name));
+                }
+                break;
+            default:
+                throw new FortnoxException('Invalid token driver: '.config('fortnox.token_driver'));
+        }
+    }
+
+    /**
      * Check if a token exists
      * @param string $name
      * @throws FortnoxException


### PR DESCRIPTION
Support for handling the Authentication process directly inside the package instead of having to retrieve the access tokens manually.

In addition, the Token storage is moved from the Cache Facade to a custom Token class that supports multiple drivers. This is mainly to fix issues where the user loses its access token if `artisan cache:clear` is used.
